### PR TITLE
Compound foreign key fix

### DIFF
--- a/t/11.testdata.t
+++ b/t/11.testdata.t
@@ -11,7 +11,7 @@ use lib qw(t/lib);
 use TDCSTest;
 
 # evil globals
-my ($schema, $artist, $cd, $track);
+my ($schema, $artist, $cd, $track, $shop, $audiophile);
 
 $schema = TDCSTest->init_schema();
 
@@ -89,5 +89,20 @@ is($track->position, 3,
     q{Track position is 3});
 is($track->cd->title, q{Tocata in Chisel},
     q{Track CD is Tocata in Chisel});
+
+$shop = $schema->resultset('Shop')->find(1);
+is($shop->name, q{Potify}, q{Shop name is 'Potify'});
+
+$shop = $schema->resultset('Shop')->find(2);
+is($shop->name, q{iTunez}, q{Shop name is 'iTunez'});
+
+$shop = $schema->resultset('Shop')->find(3);
+is($shop->name, q{Media Mangler}, q{Shop name is 'Media Mangler'});
+
+$audiophile = $schema->resultset('Audiophile')->find(1);
+is($audiophile->name, q{Chisel}, q{Audiophile name is 'Chisel'});
+
+$audiophile = $schema->resultset('Audiophile')->find(2);
+is($audiophile->name, q{Darius}, q{Audiophile name is 'Darius'});
 
 done_testing;

--- a/t/20.run_tests.compound_fk.t
+++ b/t/20.run_tests.compound_fk.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+
+use Test::More 0.92;
+use lib qw(t/lib);
+use TDCSTest;
+
+# evil globals
+my ($schema, $artist, $cd);
+
+$schema = TDCSTest->init_schema();
+
+ok(defined $schema, q{schema object defined});
+
+use Test::DBIx::Class::Schema;
+
+# create a new test object
+my $schematest = Test::DBIx::Class::Schema->new({
+    # required
+    schema    => $schema,
+    namespace => 'TDCSTest::Schema',
+    moniker   => 'CDShopAudiophile',
+});
+
+# tell it what to test
+$schematest->methods({
+    columns => [qw(
+        cdid
+        shopid
+        audiophileid
+    )],
+
+    relations => [qw(
+        cd
+        shop
+        cdshop
+        audiophile
+    )],
+
+    custom => [
+    ],
+
+    resultsets => [
+    ],
+});
+
+# run the tests
+$schematest->run_tests();

--- a/t/lib/TDCSTest.pm
+++ b/t/lib/TDCSTest.pm
@@ -106,6 +106,27 @@ sub populate_schema {
             [ 3, 4, 'Chisel Suite (part 3)', 3 ],
         ],
     );
+
+    $schema->populate(
+        'Shop',
+        [
+            [ qw/shopid name/ ],
+
+            [ 1, 'Potify' ],
+            [ 2, 'iTunez' ],
+            [ 3, 'Media Mangler' ],
+        ],
+    );
+
+    $schema->populate(
+        'Audiophile',
+        [
+            [ qw/audiophileid name/ ],
+
+            [ 1, 'Chisel' ],
+            [ 2, 'Darius' ],
+        ],
+    );
 }
 
 1;

--- a/t/lib/TDCSTest/Schema.pm
+++ b/t/lib/TDCSTest/Schema.pm
@@ -8,6 +8,10 @@ __PACKAGE__->load_classes(
         Artist
         CD
         Track
+        Shop
+        Audiophile
+        CDShop
+        CDShopAudiophile
     >,
 );
 

--- a/t/lib/TDCSTest/Schema/Audiophile.pm
+++ b/t/lib/TDCSTest/Schema/Audiophile.pm
@@ -1,0 +1,17 @@
+package # hide from PAUSE
+    TDCSTest::Schema::Audiophile;
+
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->table('audiophile');
+
+__PACKAGE__->add_columns(
+    qw<
+        audiophileid
+        name
+    >
+);
+
+__PACKAGE__->set_primary_key('audiophileid');
+
+1;

--- a/t/lib/TDCSTest/Schema/CDShop.pm
+++ b/t/lib/TDCSTest/Schema/CDShop.pm
@@ -1,0 +1,35 @@
+package # hide from PAUSE
+    TDCSTest::Schema::CDShop;
+
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->table('cd_shop');
+
+__PACKAGE__->add_columns(
+    qw<
+        cdid
+        shopid
+    >
+);
+
+__PACKAGE__->set_primary_key(qw/cdid shopid/);
+
+__PACKAGE__->belongs_to(
+    cd => 'TDCSTest::Schema::CD',
+    { 'foreign.cdid' => 'self.cdid' },
+);
+
+__PACKAGE__->belongs_to(
+    shop => 'TDCSTest::Schema::Shop',
+    { 'foreign.shopid' => 'self.shopid' }
+);
+
+__PACKAGE__->has_many(
+    cdshop_audiophiles => 'TDCSTest::Schema::CDShopAudiophile',
+    [
+        { 'foreign.cdid' => 'self.cdid' },
+        { 'foreign.shopid' => 'self.shopid' },
+    ],
+);
+
+1;

--- a/t/lib/TDCSTest/Schema/CDShopAudiophile.pm
+++ b/t/lib/TDCSTest/Schema/CDShopAudiophile.pm
@@ -1,0 +1,41 @@
+package # hide from PAUSE
+    TDCSTest::Schema::CDShopAudiophile;
+
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->table('cdshop_audiophile');
+
+__PACKAGE__->add_columns(
+    qw<
+        cdid
+        shopid
+        audiophileid
+    >
+);
+
+__PACKAGE__->set_primary_key(qw/cdid shopid audiophileid/);
+
+__PACKAGE__->belongs_to(
+    cd => 'TDCSTest::Schema::CD',
+    { 'foreign.cdid' => 'self.cdid' }
+);
+
+__PACKAGE__->belongs_to(
+    shop => 'TDCSTest::Schema::Shop',
+    { 'foreign.shopid' => 'self.shopid' }
+);
+
+__PACKAGE__->belongs_to(
+    cdshop => 'TDCSTest::Schema::CDShop',
+    [
+        { 'foreign.cdid' => 'self.cdid' },
+        { 'foreign.shopid' => 'self.shopid' },
+    ]
+);
+
+__PACKAGE__->belongs_to(
+    audiophile => 'TDCSTest::Schema::Audiophile',
+    { 'foreign.audiophileid' => 'self.audiophileid' }
+);
+
+1;

--- a/t/lib/TDCSTest/Schema/Shop.pm
+++ b/t/lib/TDCSTest/Schema/Shop.pm
@@ -1,0 +1,17 @@
+package # hide from PAUSE
+    TDCSTest::Schema::Shop;
+
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->table('shop');
+
+__PACKAGE__->add_columns(
+    qw<
+        shopid
+        name
+    >
+);
+
+__PACKAGE__->set_primary_key('shopid');
+
+1;

--- a/t/lib/sqlite.sql
+++ b/t/lib/sqlite.sql
@@ -19,3 +19,26 @@ CREATE TABLE track (
   title varchar(100) NOT NULL,
   last_updated_on datetime NULL
 );
+
+CREATE TABLE shop (
+  shopid INTEGER PRIMARY KEY NOT NULL,
+  name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE cd_shop (
+  cdid INTEGER NOT NULL,
+  shopid INTEGER NOT NULL,
+  PRIMARY KEY ( cdid, shopid )
+);
+
+CREATE TABLE audiophile (
+  audiophileid INTEGER PRIMARY KEY NOT NULL,
+  name VARCHAR(100)
+);
+
+CREATE TABLE cdshop_audiophile (
+  cdid INTEGER NOT NULL,
+  shopid INTEGER NOT NULL,
+  audiophileid INTEGER NOT NULL,
+  PRIMARY KEY ( cdid, shopid, audiophileid )
+);


### PR DESCRIPTION
Fixed a bug where compound foreign keys were causing Test::DBIC::Schema to fail and added a test for it
- SHA: 0c833524308a83f3a84be7641dd75d3642bec509
