### PR TITLE
Add (failing) test for Mooseified resultset classes

### DIFF
--- a/t/20.run_tests.artist.moose_rs.t
+++ b/t/20.run_tests.artist.moose_rs.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+
+use Test::More;
+use lib qw(t/lib);
+use TDCSTest;
+
+# This test checks that this distribution works resultset classes that make use
+# of Moose as DBIC's docs suggest (see
+# https://metacpan.org/pod/DBIx::Class::ResultSet#CUSTOM-ResultSet-CLASSES-THAT-USE-Moose)
+
+my $schema = TDCSTest->init_schema();
+isa_ok($schema, 'TDCSTest::Schema');
+
+use Test::DBIx::Class::Schema;
+
+# create a new test object
+my $schematest = Test::DBIx::Class::Schema->new({
+    # required
+    schema    => $schema,
+    namespace => 'TDCSTest::Schema',
+    moniker   => 'Artist',
+});
+
+# Set the resultset class
+$schematest->{schema}->source('Artist')
+    ->resultset_class('TDCSTest::ResultSet::ArtistMoose');
+
+# tell it what to test
+$schematest->methods({
+    columns => [qw(
+        artistid
+        personid
+        name
+    )],
+
+    relations => [qw(
+        person
+        cds
+    )],
+
+    custom => [
+    ],
+
+    resultsets => [qw/
+        artists
+    /],
+});
+
+# run the tests
+$schematest->run_tests();

--- a/t/lib/TDCSTest/ResultSet/ArtistMoose.pm
+++ b/t/lib/TDCSTest/ResultSet/ArtistMoose.pm
@@ -1,0 +1,16 @@
+package # hide from PAUSE
+    TDCSTest::ResultSet::ArtistMoose;
+
+# From https://metacpan.org/pod/DBIx::Class::ResultSet#CUSTOM-ResultSet-CLASSES-THAT-USE-Moose
+use Moose;
+use namespace::autoclean;
+use MooseX::NonMoose;
+extends 'DBIx::Class::ResultSet';
+
+sub BUILDARGS { $_[2] }
+
+sub artists { shift }
+
+__PACKAGE__->meta->make_immutable;
+
+1;


### PR DESCRIPTION
A test for this issue I just raised: https://github.com/chiselwright/test-dbix-class-schema/issues/10
