### PR TITLE
New result

### DIFF
--- a/lib/Test/DBIx/Class/Schema.pm
+++ b/lib/Test/DBIx/Class/Schema.pm
@@ -46,7 +46,7 @@ sub run_tests {
     # create a new resultset object and perform tests on it
     # - this allows us to test ->my_column() without requiring data
     $rs = $schema->resultset( $self->{moniker} );
-    $record = $schema->resultset( $self->{moniker} )->new({});
+    $record = $schema->resultset( $self->{moniker} )->new_result({});
 
     # make sure our record presents itself as the correct object type
     if (defined $self->{glue}) {

--- a/t/40.untested.fail_columns.t
+++ b/t/40.untested.fail_columns.t
@@ -1,0 +1,86 @@
+use strict;
+use warnings;
+use Test::More 0.92;
+use Test::Builder::Tester;
+
+use Test::DBIx::Class::Schema;
+
+use lib 't/lib';
+use UnexpectedTest;
+
+# we plan the number of tests so that we don't get ourselves into trouble with
+# done_testing being called multiple times
+plan tests => 10;
+
+# evil globals
+my ($schema);
+
+$schema = UnexpectedTest->init_schema();
+isa_ok($schema, 'UnexpectedTest::Schema');
+
+# create a new test object
+my $schematest = Test::DBIx::Class::Schema->new({
+    # required
+    schema    => $schema,
+    namespace => 'UnexpectedTest::Schema',
+    moniker   => 'SpanishInquisition',
+    test_missing => 1,
+});
+isa_ok($schematest, 'Test::DBIx::Class::Schema');
+
+# setup columns to test
+$schematest->methods({
+    columns => [qw(id name)],
+    relations => [],
+    custom => [],
+    resultsets => [],
+});
+
+
+FORGOT_TO_TEST: {
+    # stop testing one of the columns we know we have defined
+    $schematest->methods({
+        columns     => [qw(id)],
+        relations   => [],
+        custom      => [],
+        resultsets  => [],
+    });
+
+    test_out(
+        q{ok 1 - use UnexpectedTest::Schema;},
+        q{ok 2 - The object isa UnexpectedTest::Schema},
+        q{ok 3 - The record object is a ::SpanishInquisition},
+        q{ok 4 - 'id' column defined in result_source},
+        q{ok 5 - 'id' column exists in database},
+        q{ok 6 # skip no relations methods},
+        q{ok 7 # skip no custom methods},
+        q{ok 8 # skip no resultsets methods},
+        q{not ok 9 - All known columns defined in test},
+        q{ok 10 - All known relations defined in test},
+    );
+
+
+# ok 1 - use UnexpectedTest::Schema;
+# ok 2 - The object isa UnexpectedTest::Schema
+# ok 3 - The record object is a ::SpanishInquisition
+# ok 4 - 'id' column defined in result_source
+# ok 5 - 'id' column exists in database
+# ok 6 # skip no relations methods
+# ok 7 # skip no custom methods
+# ok 8 # skip no resultsets methods
+# not ok 9 - planned to run 4 but done_testing() expects 8
+
+    test_err(
+    "#   Failed test 'All known columns defined in test'",
+    "#   at /home/jason/git/public/test-dbix-class-schema/lib/Test/DBIx/Class/Schema.pm line 237.",
+    "#          got: '1'",
+    "#     expected: '0'",
+    "# Defined in schema class but untested - name",
+    );
+
+    $schematest->run_tests();
+
+    test_test(title => 'test output as expected for untested column');
+}
+
+# DO NOT USE: done_testing;


### PR DESCRIPTION
Fixes a bug when using on a class that uses extends/with

    ok 2 - An object of class 'Upload::Schema' isa 'Upload::Schema'
    not ok 3 - Error running (t_aggregate/schema/event.t):  (The constructor for DBIx::Class::ResultSet returned an object whose class is not a parent of 0 at /opt/xt/xt-perl/lib/site_perl/MooseX/NonMoose/Meta/Role/Class.pm line 159.
    # 	Upload::Schema::ResultSet::Event::new('Upload::Schema::ResultSet::Event=HASH(0x4a638c8)', 'HASH(0x4a638b0)') called at /opt/xt/xt-perl/lib/site_perl/Test/DBIx/Class/Schema.pm line 55
    # 	Test::DBIx::Class::Schema::run_tests('Test::DBIx::Class::Schema=HASH(0x4281a60)') called at t_aggregate/schema/event.t line 53
    # 	t_aggregateschemaeventt::run_the_tests('t_aggregateschemaeventt') called at /opt/xt/xt-perl/lib/site_perl/Test/Aggregate.pm line 369
    # 	eval {...} called at /opt/xt/xt-perl/lib/site_perl/Test/Aggregate.pm line 369
    # 	eval {...} called at /opt/xt/xt-perl/lib/site_perl/Test/Aggregate.pm line 351
    # 	Test::Aggregate::run_this_test_program('t_aggregateschemaeventt', 't_aggregate/schema/event.t', 1, 3, 0) called at /opt/xt/xt-perl/lib/site_perl/Test/Aggregate.pm line 316
    # 	Test::Aggregate::run('Test::Aggregate=HASH(0x1da43d0)') called at t/10-env/10-aggregated_schema.t line 26)

    #   Failed test 'Error running (t_aggregate/schema/event.t):  (The constructor for DBIx::Class::ResultSet returned an object whose class is not a parent of 0 at /opt/xt/xt-perl/lib/site_perl/MooseX/NonMoose/Meta/Role/Class.pm line 159.
    # 	Upload::Schema::ResultSet::Event::new('Upload::Schema::ResultSet::Event=HASH(0x4a638c8)', 'HASH(0x4a638b0)') called at /opt/xt/xt-perl/lib/site_perl/Test/DBIx/Class/Schema.pm line 55
    # 	Test::DBIx::Class::Schema::run_tests('Test::DBIx::Class::Schema=HASH(0x4281a60)') called at t_aggregate/schema/event.t line 53
    # 	t_aggregateschemaeventt::run_the_tests('t_aggregateschemaeventt') called at /opt/xt/xt-perl/lib/site_perl/Test/Aggregate.pm line 369
    # 	eval {...} called at /opt/xt/xt-perl/lib/site_perl/Test/Aggregate.pm line 369
    # 	eval {...} called at /opt/xt/xt-perl/lib/site_perl/Test/Aggregate.pm line 351
    # 	Test::Aggregate::run_this_test_program('t_aggregateschemaeventt', 't_aggregate/schema/event.t', 1, 3, 0) called at /opt/xt/xt-perl/lib/site_perl/Test/Aggregate.pm line 316
    # 	Test::Aggregate::run('Test::Aggregate=HASH(0x1da43d0)') called at t/10-env/10-aggregated_schema.t line 26)'
    #   at /opt/xt/xt-perl/lib/site_perl/Test/Aggregate.pm line 392.
    # ******** running tests for t_aggregate/schema/milestone.t ********