### PR TITLE
Add test coverage for special cases

### DIFF
--- a/t/10.test.dbix.class.schema.t
+++ b/t/10.test.dbix.class.schema.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 3;
+use Test::More tests => 4;
 
 use_ok('Test::DBIx::Class::Schema');
 
@@ -23,3 +23,4 @@ my $dbicschematest = Test::DBIx::Class::Schema->new(
     }
 );
 isa_ok($dbicschematest, 'Test::DBIx::Class::Schema');
+isa_ok(Test::DBIx::Class::Schema->new, 'Test::DBIx::Class::Schema');

--- a/t/20.run_tests.artist.moose_rs.t
+++ b/t/20.run_tests.artist.moose_rs.t
@@ -37,6 +37,7 @@ $schematest->methods({
     relations => [qw(
         person
         cds
+        cds_90s
     )],
 
     custom => [

--- a/t/20.run_tests.artist.t
+++ b/t/20.run_tests.artist.t
@@ -5,6 +5,10 @@ use Test::More 1.302015;
 use lib qw(t/lib);
 use TDCSTest;
 
+# This test is the only one that does not pass in a schema object. It makes
+# sure that we know how to connect and create our own object instead, which
+# most users probably do.
+
 # evil globals
 my ($schema, $artist, $cd);
 
@@ -12,13 +16,14 @@ $schema = TDCSTest->init_schema();
 
 ok(defined $schema, q{schema object defined});
 
-
 use Test::DBIx::Class::Schema;
 
 # create a new test object
 my $schematest = Test::DBIx::Class::Schema->new({
     # required
-    schema    => $schema,
+    dsn       => $schema->storage->connect_info->[0],
+    username  => '',
+    password  => '',
     namespace => 'TDCSTest::Schema',
     moniker   => 'Artist',
 });

--- a/t/20.run_tests.artist.t
+++ b/t/20.run_tests.artist.t
@@ -39,6 +39,7 @@ $schematest->methods({
     relations => [qw(
         person
         cds
+        cds_90s
     )],
 
     custom => [

--- a/t/20.run_tests.cd.t
+++ b/t/20.run_tests.cd.t
@@ -33,6 +33,8 @@ $schematest->methods({
 
     relations => [qw(
         artist
+        notes
+        liner_notes
     )],
 
     custom => [

--- a/t/30.missing_methods.t
+++ b/t/30.missing_methods.t
@@ -81,6 +81,10 @@ test_out(
     q{ok 18 - test survives with missing method in config},
 );
 
+test_err(
+    q{# 'relations' method defined in Artist but untested: cds_90s}
+);
+
 # run the tests
 lives_ok {
     $schematest->run_tests();

--- a/t/30.todo.skip.t
+++ b/t/30.todo.skip.t
@@ -1,0 +1,66 @@
+use strict;
+use warnings;
+
+use Test::Tester;
+use Test::More 1.302015;
+use lib qw(t/lib);
+use TDCSTest;
+
+# evil globals
+my ($schema, $artist, $cd);
+
+$schema = TDCSTest->init_schema();
+
+ok(defined $schema, q{schema object defined});
+
+use Test::DBIx::Class::Schema;
+
+# create a new test object
+my $schematest = Test::DBIx::Class::Schema->new({
+    # required
+    schema    => $schema,
+    namespace => 'TDCSTest::Schema',
+    moniker   => 'Artist',
+});
+
+# tell it what to test
+$schematest->methods({
+    columns => [
+    ],
+    
+    relations => [qw(
+        cds_90s
+    )],
+
+    custom => [
+    ],
+
+    resultsets => [
+    ],
+});
+
+# stop TDCS from doing done_testing on our behalf
+$ENV{TEST_AGGREGATE} = 1;
+
+# run the tests, but capture the results...
+my ( $premature, @results ) = run_tests(
+    sub {
+        $schematest->run_tests();
+    }
+);
+
+# ... so we can check for todos...
+ok $results[5]->{type} eq 'todo'
+    && $results[5]->{reason} eq 'skipping column tests for CODE defined condition',
+    'coderef condition was skipped with TODO';
+
+# ... and skips
+ok $results[6]->{type} eq 'skip'
+    && $results[6]->{reason} eq 'no custom methods',
+    'custom method test was skipped';
+ok $results[7]->{type} eq 'skip'
+    && $results[7]->{reason} eq 'no resultsets methods',
+    'custom method test was skipped';
+
+# we need to explicitly say we're done
+done_testing;

--- a/t/lib/TDCSTest/Schema.pm
+++ b/t/lib/TDCSTest/Schema.pm
@@ -13,6 +13,7 @@ __PACKAGE__->load_classes(
         Person
         Shop
         Track
+        LinerNotes
     >,
 );
 

--- a/t/lib/TDCSTest/Schema/Artist.pm
+++ b/t/lib/TDCSTest/Schema/Artist.pm
@@ -19,4 +19,19 @@ __PACKAGE__->belongs_to( person => 'TDCSTest::Schema::Person', 'personid' );
 
 __PACKAGE__->has_many( 'cds' => 'TDCSTest::Schema::CD', 'artistid' );
 
+# borrowed from https://metacpan.org/pod/DBIx::Class::Relationship::Base#Custom-join-conditions
+# though we could probably also just have an empty return value, but if this TODO block
+# gets removed it makes sense to have a working condition here
+__PACKAGE__->has_many(
+    cds_90s => 'TDCSTest::Schema::CD',
+    sub {
+        my $args = shift;
+     
+        return {
+            "$args->{foreign_alias}.artist" => { -ident => "$args->{self_alias}.artistid" },
+            "$args->{foreign_alias}.year"   => { '>', "1989", '<', "2000" },
+        };
+    }
+);
+
 1;

--- a/t/lib/TDCSTest/Schema/CD.pm
+++ b/t/lib/TDCSTest/Schema/CD.pm
@@ -27,5 +27,10 @@ __PACKAGE__->belongs_to(
     { 'foreign.artistid_foreign' => 'self.artistid' }
 );
 
+__PACKAGE__->might_have(liner_notes => 'TDCSTest::Schema::LinerNotes',
+    undef, {
+        proxy => [ qw/notes/ ],
+    }
+);
 
 1;

--- a/t/lib/TDCSTest/Schema/LinerNotes.pm
+++ b/t/lib/TDCSTest/Schema/LinerNotes.pm
@@ -1,0 +1,21 @@
+package # hide from PAUSE
+    TDCSTest::Schema::LinerNotes;
+ 
+use base 'DBIx::Class::Core';
+ 
+__PACKAGE__->table('liner_notes');
+__PACKAGE__->add_columns(
+  'liner_id' => {
+    data_type => 'integer',
+  },
+  'notes' => {
+    data_type => 'varchar',
+    size      => 100,
+  },
+);
+__PACKAGE__->set_primary_key('liner_id');
+__PACKAGE__->belongs_to(
+  'cd', 'TDCSTest::Schema::CD', 'liner_id'
+);
+ 
+1;

--- a/t/lib/sqlite.sql
+++ b/t/lib/sqlite.sql
@@ -50,3 +50,8 @@ CREATE TABLE person (
   personid INTEGER PRIMARY KEY NOT NULL,
   first_name VARCHAR(100)
 );
+
+CREATE TABLE liner_notes (
+  liner_id INTEGER NOT NULL,
+  notes VARCHAR(100)
+);


### PR DESCRIPTION
This PR adds coverage for CODE reference relations, proxy relationships and a bunch small things. I tried adding tests for failing tests as well but ran into some trouble with Test::Builder::Tester. I might add more commits with a different approach later or create a second PR.

This is my entry for the pull request challenge 2017 in June.